### PR TITLE
Add CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,28 @@
+# CLAUDE.md
+
+## リポジトリ概要
+
+[ohakutsu - Qiita](https://qiita.com/ohakutsu) の記事を [qiita-cli](https://github.com/increments/qiita-cli) で管理するリポジトリ。ソースコードは含まず、記事の Markdown ファイルのみを扱う。
+
+- `public/*.md`: 各記事。ファイル名は Qiita の記事 ID（新規記事は publish 時に ID へリネームされる）
+- 各記事の先頭に YAML frontmatter（`title`, `tags`, `private`, `id`, `updated_at` など）がある。`id` と `updated_at` は qiita-cli が管理するため手動で書き換えない
+
+## セットアップ
+
+ツール（Node.js / qiita-cli）は mise で管理されている。
+
+```bash
+./devtools/scripts/setup-development-environment.sh  # mise trust && mise install
+```
+
+## よく使うコマンド
+
+```bash
+qiita new <ファイルのベース名>  # 新規記事の雛形を public/ に作成
+qiita preview                   # ブラウザでプレビュー（http://localhost:8888）
+qiita pull                      # Qiita 上の記事をローカルに取り込む
+```
+
+## 公開フロー
+
+main ブランチへの push をトリガーに GitHub Actions（`.github/workflows/publish.yml`）が qiita-cli の publish アクションを実行し、Qiita へ反映する。ローカルから `qiita publish` を直接実行する必要はない。記事の作成・更新は PR を作って main にマージする。


### PR DESCRIPTION
## What

Claude Code 向けのプロジェクト概要ドキュメント `CLAUDE.md` をリポジトリ直下に追加する。

## How

- リポジトリの目的（qiita-cli による Qiita 記事管理）、記事ファイルの配置、YAML frontmatter の運用ルールを記載
- `mise` によるセットアップ手順とセットアップスクリプトへの参照を記載
- `qiita new` / `qiita preview` / `qiita pull` などよく使うコマンドを一覧化
- 公開フロー（main ブランチ push で GitHub Actions が publish）を記載し、ローカル publish が不要なことを明示

## Why

Claude Code などの AI エージェントがこのリポジトリで作業する際に、qiita-cli 特有の制約（`id`/`updated_at` を手動編集しない、記事ファイル名は Qiita の記事 ID、publish は GitHub Actions 経由）を毎回コードから推測する必要をなくすため。

## Ref

- https://github.com/increments/qiita-cli