### PR TITLE
Add article about .chezmoiremove tips

### DIFF
--- a/public/dae729d17cc3337fd90a.md
+++ b/public/dae729d17cc3337fd90a.md
@@ -1,0 +1,55 @@
+---
+title: '[Tips] chezmoiの管理から外したファイルがローカルに残り続ける問題を.chezmoiremoveで解消する'
+tags:
+  - tips
+  - dotfiles
+  - chezmoi
+private: false
+updated_at: '2026-07-08T19:04:00+09:00'
+id: dae729d17cc3337fd90a
+organization_url_name: qiita-inc
+slide: false
+ignorePublish: false
+posting_campaign_uuid: 783b7a849caf11eefd91
+agreed_posting_campaign_term: true
+---
+## はじめに
+
+dotfilesを[chezmoi](https://github.com/twpayne/chezmoi)で管理しているのですが、使わなくなったファイルをソースディレクトリから削除しても、ターゲットの実ファイルはそのまま残り続けます。
+
+https://github.com/twpayne/chezmoi/discussions/1446
+
+複数マシンで運用していると他のマシンに使わなくなったファイルが残り続けてしまうので、`.chezmoiremove`ファイルを使って削除されるようにしているので、紹介します。
+
+## .chezmoiremove について
+
+https://www.chezmoi.io/reference/special-files/chezmoiremove/
+
+> If a file called .chezmoiremove (with an optional .tmpl extension) exists in the source state then it is interpreted as a list of targets to remove. .chezmoiremove is interpreted as a template, whether or not it has a .tmpl extension.
+
+> ソース状態で「.chezmoiremove」という名前のファイル（オプションで「.tmpl」という拡張子が付いている場合もある）が存在する場合、そのファイルは削除対象のリストとして解釈されます。「.chezmoiremove」は、拡張子が「.tmpl」であるかどうかにかかわらず、テンプレートとして解釈されます。
+>
+> _DeepLによる日本語訳_
+
+リファレンスの説明の通り、削除対象のターゲットのリストとして解釈され、`chezmoi apply`のタイミングで該当するファイルが削除されます。
+
+そのため、`.chezmoiremove`自体をGit管理することで、どのマシンでも`chezmoi apply`をするだけで削除できるようになります。
+
+```text:.chezmoiremoveの例
+.config/alacritty/alacritty.toml
+.config/zellij/config.kdl
+```
+
+## 私の運用例
+
+`.chezmoiremove`は「ファイルを管理から外すときに追記する」という性質上、つい忘れがちです。
+私はdotfilesリポジトリにルールとして明文化し、ClaudeやCodexから参照できるようにしておくことで、私が忘れてもレビューでAIが指摘してくれるようにしています。
+
+```markdown:CLAUDE.mdの一部
+- chezmoi 管理から外すファイルは `.chezmoiremove` にも追記する
+  - ソースから消すだけではターゲット（ホーム）の実ファイルは残るため
+```
+
+## さいごに
+
+chezmoiの管理から外したファイルがローカルに残り続ける問題は、`.chezmoiremove`に追記することで解消できます。


### PR DESCRIPTION
## What

chezmoi の管理から外したファイルがローカルに残り続ける問題を `.chezmoiremove` で解消する Tips 記事を新規追加する。

## How

- `public/dae729d17cc3337fd90a.md` に記事本文を配置
- `.chezmoiremove` の概要、私の運用例（dotfiles リポジトリの CLAUDE.md にルールとして明文化して AI レビューで補完する運用）を紹介

## Why

- 複数マシンで dotfiles を運用していると、使わなくなったファイルが他のマシンに残り続ける課題があり、その解消方法として `.chezmoiremove` を共有するため

## Ref

- https://www.chezmoi.io/reference/special-files/chezmoiremove/
- https://github.com/twpayne/chezmoi/discussions/1446